### PR TITLE
fix(night): makes it work with newer? loader-utils 🚑

### DIFF
--- a/src/storybook/select-components-loader.js
+++ b/src/storybook/select-components-loader.js
@@ -1,4 +1,4 @@
-import loaderUtils from 'loader-utils'
+import { stringifyRequest, getOptions } from 'loader-utils'
 import pathNode, { packagesPath } from '../path'
 
 const storyPath = 'stories/index.js'
@@ -10,7 +10,7 @@ module.exports = function (source) {
 
 	loader.cacheable && loader.cacheable()
 
-	let { components } = loaderUtils.parseQuery(loader.query)
+	let { components } = getOptions(loader)
 
 	if (!components) components = []
 
@@ -18,7 +18,7 @@ module.exports = function (source) {
 
 		let componentPath = pathNode.join(packagesPath, componentName, storyPath)
 
-		componentPath = loaderUtils.stringifyRequest(loader, componentPath)
+		componentPath = stringifyRequest(loader, componentPath)
 
 		return `require(${componentPath})`
 


### PR DESCRIPTION
scot4 dev was constantly failing to build any component throwing:

```
ERROR in ./packages/entry/storybull.js
Module build failed: TypeError: _loaderUtils2.default.parseQuery is not a function
    at Object.module.exports (/usr/local/lib/node_modules/scot4/lib/storybook/select-components-loader.js:22:52)
 @ /usr/local/lib/~/scot4/lib/storybook/config.js 3:0-26
```

so i went through the code and found out that [loader-utils no longer](https://github.com/webpack/loader-utils/commit/dfe2608c0f0b3b816df816da63bb532b5609515a#diff-6d186b954a58d5bb740f73d84fe39073) [exports](https://github.com/webpack/loader-utils/blob/master/lib/index.js) parseQuery. 
I've fixed select-components-loader.js to work with newer loader-utils API.